### PR TITLE
Add missing value for parameter

### DIFF
--- a/.local/bin/cron/checkup
+++ b/.local/bin/cron/checkup
@@ -2,7 +2,7 @@
 
 # Syncs repositories and downloads updates, meant to be run as a cronjob.
 
-ping -q -c example.org > /dev/null || exit
+ping -q -c 1 example.org > /dev/null || exit
 
 notify-send "📦 Repository Sync" "Checking for package updates..."
 


### PR DESCRIPTION
The value of the "-c" parameter was missing, so the check for an active internet connection as well as the whole script failed.